### PR TITLE
Use class instead of TypeToken object

### DIFF
--- a/src/main/java/io/scif/labeling/DefaultLabelingIOService.java
+++ b/src/main/java/io/scif/labeling/DefaultLabelingIOService.java
@@ -257,9 +257,7 @@ public class DefaultLabelingIOService extends AbstractService implements
 	{
 		final Writer writer = new FileWriter(LabelingUtil.getFilePathWithExtension(
 			file, LabelingUtil.LBL_ENDING, Paths.get(file).getParent().toString()));
-		final Type labelingDataType = new TypeToken<LabelingData<T, S>>() {}
-			.getType();
-		this.gson.toJson(labelingData, labelingDataType, writer);
+		this.gson.toJson(labelingData, LabelingData.class, writer);
 		writer.flush();
 		writer.close();
 	}


### PR DESCRIPTION
This seems to pass tests with gson version `33.4.8-jre`, although I didn't think about the changeset that hard...